### PR TITLE
fix: Fix disappearing sidebar [PT-187321139]

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -65,6 +65,8 @@
     margin: 10px;
 
     .left {
+      overflow: hidden;
+
       display: flex;
       flex-direction: column;
       justify-content: space-between;

--- a/src/components/graph.tsx
+++ b/src/components/graph.tsx
@@ -764,8 +764,8 @@ export const Graph = (props: Props) => {
   return (
     <div className="graph" ref={wrapperRef} onClick={handleClick}>
       <svg
-        width={width}
-        height={height}
+        width="100%"
+        height="calc(100vh - 20px)"
         viewBox={viewBox}
         ref={svgRef}
       />

--- a/src/components/toolbar.scss
+++ b/src/components/toolbar.scss
@@ -6,6 +6,7 @@
   border-radius: 3px;
   background-color: #dddddd7f;
   justify-content: space-between;
+  gap: 10px;
 
   button {
     width: 32px;


### PR DESCRIPTION
Changed svg graph to use calculated height and 100% width to force svg to stay within the graph container.

Also added 10px gap to toolbar between top and bottom button groups.