### PR TITLE
fix: negative-probabilities-in-transition-dialogue

### DIFF
--- a/src/components/drawing/probability-selector.tsx
+++ b/src/components/drawing/probability-selector.tsx
@@ -128,8 +128,9 @@ export const ProbabilitySelector = ({exactPercentages, edgeLabels, onChange}: Pr
     const newExactPercentages = [...exactPercentages];
     newExactPercentages[index] = newExactPercentage;
     newExactPercentages[index+1] = pairedPercentageSum - newExactPercentage;
-
-    onChange(newExactPercentages);
+    if (newExactPercentages.find((n) => n<0) == undefined) {
+      onChange(newExactPercentages);
+    }
   }, [exactPercentages, onChange]);
 
   if (exactPercentages.length < 2) {


### PR DESCRIPTION
Add in a line so that it will only change the thumbs if none of the percentages are less than 0