### PR TITLE
fix: Set min-width on right nav

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -88,6 +88,7 @@
       flex-direction: column;
       flex: 1;
       flex-grow: 0;
+      min-width: 160px;
       gap: 10px;
       background-color: #dddddd7f;
       border-radius: 3px;


### PR DESCRIPTION
This prevents the right nav from growing and shrinking when the play/pause/resume button changes widths.