### PR TITLE
fix: Negative probability slider [PT-187357469]

### DIFF
--- a/src/components/drawing/probability-selector.tsx
+++ b/src/components/drawing/probability-selector.tsx
@@ -129,7 +129,10 @@ export const ProbabilitySelector = ({exactPercentages, edgeLabels, onChange}: Pr
     newExactPercentages[index] = newExactPercentage;
     newExactPercentages[index+1] = pairedPercentageSum - newExactPercentage;
 
-    onChange(newExactPercentages);
+    const allAboveZero = newExactPercentages.find(n => n < 0) === undefined;
+    if (allAboveZero) {
+      onChange(newExactPercentages);
+    }
   }, [exactPercentages, onChange]);
 
   if (exactPercentages.length < 2) {


### PR DESCRIPTION
This ensures that no probability values can go below zero.