### PR TITLE
fix: Working reset fix [PT-187399412]

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -534,16 +534,20 @@ export const App = () => {
         setSequenceGroups([]);
         setFastSimulation(defaultFastSimulation);
         setGraphOpacity(0);
-        setGraph(initialGraph ? {...initialGraph} : {nodes: [], edges: []});
+        setSelectedNodeId();
+        setGraph({nodes: [], edges: []});
         setResetViewAt(Date.now());
         setTimeout(() => {
+          if (initialGraph) {
+            setGraph(initialGraph);
+          }
           setFitViewAt(Date.now());
           setGraphOpacity(1);
-        }, 0);
+        }, 1);
       },
       onClose: () => setConfirmModal(undefined)
     });
-  }, [initialGraph, setGraph]);
+  }, [initialGraph, setGraph, setSelectedNodeId]);
 
   const handleReturnToMainMenu = () => {
     setConfirmModal({

--- a/src/components/graph.tsx
+++ b/src/components/graph.tsx
@@ -391,13 +391,16 @@ export const Graph = (props: Props) => {
     const {minRadius, maxRadius, minStroke, maxStroke} = settings;
 
     graph.nodes.forEach((node, index) => {
+      const oldD3Node = d3Graph.nodes.find(n => n.id === node.id);
+      const x = oldD3Node?.x ?? node.x ?? 0;
+      const y = oldD3Node?.y ?? node.y ?? 0;
+
       const d3Node: D3Node = {
         index,
         id: node.id,
-        x: node.x ?? 0,
-        y: node.y ?? 0,
+        x,
+        y,
         label: node.label,
-        // radius: 15 + (5 * (node.label.length - 1)) + (5 * node.value),
         radius: minRadius + ((maxRadius - minRadius) * (node.value / totalNodeValue)),
         loops: false,
         loopWeight: 0,


### PR DESCRIPTION
- On reset the graph is now initially hidden and set to empty, then after a timeout set to the initial graph and redrawn and then shown
- The old graph node x,y is now not updated
- The selected node (if any) is unset